### PR TITLE
Fix memory allocation and error handling in binfile_utils.cpp and prover.cpp

### DIFF
--- a/src/binfile_utils.cpp
+++ b/src/binfile_utils.cpp
@@ -12,6 +12,11 @@ BinFile::BinFile(const void *fileData, size_t fileSize, std::string _type, uint3
 
     size = fileSize;
     addr = malloc(size);
+
+    if (addr == nullptr) {
+        throw std::runtime_error("Memory allocation failed for BinFile.");
+    }
+
     memcpy(addr, fileData, size);
 
     type.assign((const char *)addr, 4);
@@ -19,7 +24,7 @@ BinFile::BinFile(const void *fileData, size_t fileSize, std::string _type, uint3
 
     if (type != _type) {
         free(addr);
-        throw new std::invalid_argument("Invalid file type. It should be " + _type + " and it is " + type);
+        throw std::invalid_argument("Invalid file type. It should be " + _type + " and it is " + type);
     }
 
     version = readU32LE();

--- a/src/binfile_utils.cpp
+++ b/src/binfile_utils.cpp
@@ -14,7 +14,7 @@ BinFile::BinFile(const void *fileData, size_t fileSize, std::string _type, uint3
     addr = malloc(size);
 
     if (addr == nullptr) {
-        throw std::runtime_error("Memory allocation failed for BinFile.");
+        throw new std::runtime_error("Memory allocation failed for BinFile.");
     }
 
     memcpy(addr, fileData, size);
@@ -24,7 +24,7 @@ BinFile::BinFile(const void *fileData, size_t fileSize, std::string _type, uint3
 
     if (type != _type) {
         free(addr);
-        throw std::invalid_argument("Invalid file type. It should be " + _type + " and it is " + type);
+        throw new std::invalid_argument("Invalid file type. It should be " + _type + " and it is " + type);
     }
 
     version = readU32LE();

--- a/src/fullprover.cpp
+++ b/src/fullprover.cpp
@@ -217,8 +217,11 @@ ProverResponse FullProverImpl::prove(const char *witness_file_path) const {
     log_info("constructing metrics struct");
     ProverResponseMetrics metrics;
     metrics.prover_time = prover_duration.count();
-    
+
     const char *proof_raw = strdup(proof.dump().c_str());
+    if (proof_raw == nullptr) {
+      throw std::runtime_error("Failed to allocate memory for proof_raw");
+    }
 
     log_info("FullProverImpl::prove end");
     return ProverResponse(proof_raw, metrics);

--- a/src/prover.cpp
+++ b/src/prover.cpp
@@ -24,6 +24,12 @@ static size_t PublicBufferMinSize(size_t count)
     return count * 82 + 4;
 }
 
+/**
+ * Verifies the given prime numbers.
+ *
+ * @param zkey_prime A pointer to the first prime number.
+ * @param wtns_prime A pointer to the second prime number.
+ */
 static void VerifyPrimes(mpz_srcptr zkey_prime, mpz_srcptr wtns_prime)
 {
     mpz_t altBbn128r;
@@ -42,6 +48,13 @@ static void VerifyPrimes(mpz_srcptr zkey_prime, mpz_srcptr wtns_prime)
     mpz_clear(altBbn128r);
 }
 
+/**
+ * Builds a JSON string representation of the public data.
+ * 
+ * @param wtnsData Pointer to an array of AltBn128::FrElement representing the public data.
+ * @param nPublic The number of elements in the public data array.
+ * @return A JSON string representation of the public data.
+ */
 std::string BuildPublicString(AltBn128::FrElement *wtnsData, size_t nPublic)
 {
     json jsonPublic;
@@ -54,6 +67,13 @@ std::string BuildPublicString(AltBn128::FrElement *wtnsData, size_t nPublic)
     return jsonPublic.dump();
 }
 
+/**
+ * Calculates the size of the public buffer required for the given zkey buffer.
+ *
+ * @param zkey_buffer A pointer to the zkey buffer.
+ * @param zkey_size The size of the zkey buffer.
+ * @return The size of the public buffer required.
+ */
 unsigned long CalcPublicBufferSize(const void *zkey_buffer, unsigned long zkey_size) {
     try {
         BinFileUtils::BinFile zkey(zkey_buffer, zkey_size, "zkey", 1);
@@ -65,6 +85,22 @@ unsigned long CalcPublicBufferSize(const void *zkey_buffer, unsigned long zkey_s
     return 0;
 }
 
+/**
+ * Proves a Groth16 proof given the necessary inputs.
+ *
+ * @param zkey_buffer       Pointer to the buffer containing the zkey data.
+ * @param zkey_size         Size of the zkey buffer.
+ * @param wtns_buffer       Pointer to the buffer containing the wtns data.
+ * @param wtns_size         Size of the wtns buffer.
+ * @param proof_buffer      Pointer to the buffer to store the generated proof.
+ * @param proof_size        Pointer to the size of the proof buffer. On input, it should contain the available size of the buffer. On output, it will be updated with the actual size of the generated proof.
+ * @param public_buffer     Pointer to the buffer to store the generated public data.
+ * @param public_size       Pointer to the size of the public buffer. On input, it should contain the available size of the buffer. On output, it will be updated with the actual size of the generated public data.
+ * @param error_msg         Pointer to the buffer to store any error message that occurs during the proving process.
+ * @param error_msg_maxsize Maximum size of the error message buffer.
+ *
+ * @return                  Returns PROVER_OK if the proving process is successful. If there is an error, it returns an appropriate error code.
+ */
 int
 groth16_prover(const void *zkey_buffer,   unsigned long  zkey_size,
                const void *wtns_buffer,   unsigned long  wtns_size,
@@ -139,21 +175,21 @@ groth16_prover(const void *zkey_buffer,   unsigned long  zkey_size,
     } catch (std::exception& e) {
 
         if (error_msg) {
-            strncpy(error_msg, e.what(), error_msg_maxsize);
+            strlcpy(error_msg, e.what(), error_msg_maxsize);
         }
         return PROVER_ERROR;
 
     } catch (std::exception *e) {
 
         if (error_msg) {
-            strncpy(error_msg, e->what(), error_msg_maxsize);
+            strlcpy(error_msg, e->what(), error_msg_maxsize);
         }
         delete e;
         return PROVER_ERROR;
 
     } catch (...) {
         if (error_msg) {
-            strncpy(error_msg, "unknown error", error_msg_maxsize);
+            strlcpy(error_msg, "unknown error", error_msg_maxsize);
         }
         return PROVER_ERROR;
     }


### PR DESCRIPTION
I added two checks to ensure no NULL pointer after memory operations, and use of `strlcpy` to ensure null terminated strings on error. I also commented on a couple of functions.